### PR TITLE
Allow passing in typed js.Array to data

### DIFF
--- a/src/main/scala/com/greencatsoft/d3/selection/DataDriven.scala
+++ b/src/main/scala/com/greencatsoft/d3/selection/DataDriven.scala
@@ -11,7 +11,7 @@ trait DataDriven[A <: Node, B <: Selection[A, B]] extends js.Object {
 
   def data[T](): js.Array[T] = js.native
 
-  def data(values: js.Array[Any]): BoundSelection[A, B] = js.native
+  def data[T](values: js.Array[T]): BoundSelection[A, B] = js.native
 
   def data[T](values: js.Array[T], key: KeyFunction[T]): BoundSelection[A, B] = js.native
 


### PR DESCRIPTION
This allows someone to pass in a js.Array[T] to data, rather than only a js.Array[Any].

I only made this change so that if I have a `List[Point]`, for example, I can pass in `myList.toJSArray`, without converting it to a `js.Array[Any]`.